### PR TITLE
Use constant for sources heading

### DIFF
--- a/src/components/common/SourceList.tsx
+++ b/src/components/common/SourceList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { GroundingSource } from '../../types/index';
+import { SOURCES_TITLE } from '../../constants';
 
 interface SourceListProps {
   sources: GroundingSource[];
@@ -12,7 +13,7 @@ export const SourceList: React.FC<SourceListProps> = ({ sources }: SourceListPro
 
   return (
     <div className="space-y-2">
-      <p className="text-xs font-medium text-gray-500">Sources:</p>
+      <p className="text-xs font-medium text-gray-500">{SOURCES_TITLE}</p>
       <div className="flex flex-wrap gap-2">
         {sources.map((source, index) => (
           <a


### PR DESCRIPTION
## Summary
- import `SOURCES_TITLE` and use it in `SourceList`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a8efa8bb88333bd8f3c46ecdcac40