### PR TITLE
[Fix] tighten CORS and add rate limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,11 @@ VERCEL_URL=
 
 # Node.js environment
 NODE_VERSION=20.x
+
+# Allowed origins for CORS (comma separated)
+ALLOWED_ORIGINS=http://localhost:3000
+
+# Rate limiting settings
+RATE_LIMIT_WINDOW_MS=60000
+RATE_LIMIT_MAX=60
+

--- a/api/[...path].ts
+++ b/api/[...path].ts
@@ -1,13 +1,56 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import chatHandler from './chat';
 
-// This is a simple router for Vercel serverless functions
-const handler = async (req: VercelRequest, res: VercelResponse) => {
-  // Set CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*');
+const getAllowedOrigins = (): string[] =>
+  process.env.ALLOWED_ORIGINS
+    ? process.env.ALLOWED_ORIGINS.split(',')
+        .map((o) => o.trim())
+        .filter(Boolean)
+    : [];
+
+const applyCorsHeaders = (req: VercelRequest, res: VercelResponse): void => {
+  const origin = req.headers.origin as string | undefined;
+  const allowedOrigins = getAllowedOrigins();
+  if (origin && allowedOrigins.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+  }
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-  
+};
+
+const rateLimitMap = new Map<string, { count: number; start: number }>();
+const RATE_LIMIT_WINDOW = parseInt(process.env.RATE_LIMIT_WINDOW_MS || '60000', 10);
+const RATE_LIMIT_MAX = parseInt(process.env.RATE_LIMIT_MAX || '60', 10);
+
+const checkRateLimit = (req: VercelRequest, res: VercelResponse): boolean => {
+  const ip =
+    ((req.headers['x-forwarded-for'] as string) || '').split(',')[0].trim() ||
+    req.socket.remoteAddress ||
+    'unknown';
+  const now = Date.now();
+  const entry = rateLimitMap.get(ip) || { count: 0, start: now };
+  if (now - entry.start > RATE_LIMIT_WINDOW) {
+    entry.start = now;
+    entry.count = 1;
+  } else {
+    entry.count += 1;
+  }
+  rateLimitMap.set(ip, entry);
+  if (entry.count > RATE_LIMIT_MAX) {
+    res.status(429).json({ error: 'Too Many Requests' });
+    return true;
+  }
+  return false;
+};
+
+// This is a simple router for Vercel serverless functions
+const handler = async (req: VercelRequest, res: VercelResponse) => {
+  applyCorsHeaders(req, res);
+
+  if (req.method !== 'OPTIONS' && checkRateLimit(req, res)) {
+    return;
+  }
+
   // Handle preflight
   if (req.method === 'OPTIONS') {
     console.log('Handling OPTIONS preflight request');
@@ -20,7 +63,6 @@ const handler = async (req: VercelRequest, res: VercelResponse) => {
   console.log('Request body:', req.body ? JSON.stringify(req.body, null, 2) : 'No body');
 
   try {
-
     // Handle /api/chat route
     if (req.url?.startsWith('/api/chat') || req.url === '/chat') {
       console.log('Routing to chat handler');
@@ -30,26 +72,26 @@ const handler = async (req: VercelRequest, res: VercelResponse) => {
     // Handle 404 for unknown routes
     res.status(404).json({
       error: 'Not Found',
-      message: `The requested resource ${req.url} was not found.`
+      message: `The requested resource ${req.url} was not found.`,
     });
   } catch (error) {
     console.error('Unhandled error in API handler:', error);
-    
+
     const statusCode = 500;
     const errorMessage = 'Internal Server Error';
     const errorDetails = error instanceof Error ? error.message : 'An unknown error occurred';
-    
+
     console.error(`Error details: ${errorDetails}`);
     if (error instanceof Error && error.stack) {
       console.error('Error stack:', error.stack);
     }
-    
+
     res.status(statusCode).json({
       error: errorMessage,
       message: errorDetails,
       ...(process.env.NODE_ENV !== 'production' && {
-        stack: error instanceof Error ? error.stack : undefined
-      })
+        stack: error instanceof Error ? error.stack : undefined,
+      }),
     });
   }
 };


### PR DESCRIPTION
## Summary
- restrict CORS origins using `ALLOWED_ORIGINS` env variable
- add simple in-memory rate limiter
- document new env vars

## Testing
- `npx prettier --write api/'[...path].ts' api/chat/route.ts .env.example --ignore-unknown`
- `npx eslint -c .eslintrc.cjs api/'[...path].ts' api/chat/route.ts` *(fails: Environment key "vitest/globals" is unknown)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c0910a2808333aaa0c9f188efa5c9