### PR TITLE
[Feat] improve loading indicator accessibility

### DIFF
--- a/src/components/common/LoadingIndicator.tsx
+++ b/src/components/common/LoadingIndicator.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from "react";
-import { LOADING_INDICATOR_TEXT } from "@/constants";
-import "../styles/animations.css";
+import React, { useEffect, useState } from 'react';
+import { LOADING_INDICATOR_TEXT } from '@/constants';
+import '../styles/animations.css';
 
-const dots = [".", "..", "..."];
+const dots = ['.', '..', '...'];
 
 export const LoadingIndicator: React.FC = () => {
   const [activeDot, setActiveDot] = useState(0);
@@ -17,21 +17,21 @@ export const LoadingIndicator: React.FC = () => {
 
   return (
     <div className="flex items-center space-x-2">
-      <div className="flex space-x-1.5">
-        {[0, 1, 2].map((i) => (
-          <div
-            key={i}
-            className={`w-2 h-2 rounded-full transition-all duration-300 ${
-              i === activeDot
-                ? "bg-green-500 scale-125"
-                : "bg-green-300 scale-90"
-            }`}
-            style={{
-              animation: "pulse 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite",
-              animationDelay: `${i * 0.15}s`,
-            }}
-          />
-        ))}
+      <div role="status" aria-live="polite">
+        <div className="flex space-x-1.5">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className={`w-2 h-2 rounded-full transition-all duration-300 ${
+                i === activeDot ? 'bg-green-500 scale-125' : 'bg-green-300 scale-90'
+              }`}
+              style={{
+                animation: 'pulse 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+                animationDelay: `${i * 0.15}s`,
+              }}
+            />
+          ))}
+        </div>
       </div>
       <span className="text-sm text-gray-500 font-medium">
         {LOADING_INDICATOR_TEXT}


### PR DESCRIPTION
## Summary
- wrap animated dots with a `<div role="status" aria-live="polite">`

## Testing
- `npx eslint . --ext .ts,.tsx` *(fails: Environment key "vitest/globals" is unknown)*
- `npm run build`

Closes #1

------
https://chatgpt.com/codex/tasks/task_e_684c09190d24833393fa918224b946d3