### PR TITLE
[Feat] add vitest coverage for chat

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,7 +4,6 @@ module.exports = {
     browser: true,
     es2021: true,
     node: true,
-    'vitest/globals': true,
   },
   extends: [
     'eslint:recommended',
@@ -24,7 +23,7 @@ module.exports = {
     ecmaVersion: 'latest',
     sourceType: 'module',
   },
-  plugins: ['react', 'react-hooks', '@typescript-eslint', 'prettier', 'vitest'],
+  plugins: ['react', 'react-hooks', '@typescript-eslint', 'prettier'],
   settings: {
     react: {
       version: 'detect',
@@ -53,9 +52,6 @@ module.exports = {
   overrides: [
     {
       files: ['**/*.test.ts', '**/*.test.tsx'],
-      env: {
-        'vitest/globals': true,
-      },
     },
   ],
 };

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import App from '../App';
+
+vi.mock('../components/chat/ChatInterface', () => ({
+  default: () => <div>ChatInterface</div>,
+  ChatInterface: () => <div>ChatInterface</div>,
+}));
+
+describe('App', () => {
+  it('renders application header', () => {
+    render(<App />);
+    expect(screen.getByText('oLegal')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/ChatInterface.test.tsx
+++ b/src/__tests__/ChatInterface.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest';
+import ChatInterface from '../components/chat/ChatInterface';
+import { WELCOME_TITLE } from '../constants';
+import * as hook from '../hooks/useChat';
+import '@testing-library/jest-dom';
+
+vi.mock('../hooks/useChat');
+
+const mockUseChat = hook as { useChat: vi.Mock };
+
+describe('ChatInterface', () => {
+  beforeAll(() => {
+    Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+      value: vi.fn(),
+      writable: true,
+    });
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows welcome screen when no messages', () => {
+    mockUseChat.useChat.mockReturnValue({
+      messages: [],
+      handleSendMessage: vi.fn(),
+      error: null,
+      loading: false,
+    });
+    render(<ChatInterface />);
+    expect(screen.getByText(WELCOME_TITLE)).toBeInTheDocument();
+  });
+
+  it('renders messages when present', () => {
+    mockUseChat.useChat.mockReturnValue({
+      messages: [{ role: 'user', parts: [{ text: 'hi' }] }],
+      handleSendMessage: vi.fn(),
+      error: null,
+      loading: false,
+    });
+    render(<ChatInterface />);
+    expect(screen.queryByText(WELCOME_TITLE)).not.toBeInTheDocument();
+    expect(screen.getByText('hi')).toBeInTheDocument();
+  });
+
+  it('calls handleSendMessage on submit', async () => {
+    const send = vi.fn();
+    mockUseChat.useChat.mockReturnValue({
+      messages: [],
+      handleSendMessage: send,
+      error: null,
+      loading: false,
+    });
+    render(<ChatInterface />);
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/chat message/i), 'hello');
+    await user.click(screen.getByRole('button', { name: /send message/i }));
+    expect(send).toHaveBeenCalledWith('hello');
+  });
+});

--- a/src/__tests__/useChat.test.ts
+++ b/src/__tests__/useChat.test.ts
@@ -1,0 +1,32 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { useChat } from '../hooks/useChat';
+import * as service from '../services/geminiService';
+
+vi.mock('../services/geminiService');
+
+describe('useChat', () => {
+  it('initializes with default state', () => {
+    const { result } = renderHook(() => useChat());
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sends a message and appends response', async () => {
+    (service.sendMessage as unknown as vi.Mock).mockResolvedValue({ text: 'answer', sources: [] });
+    const { result } = renderHook(() => useChat());
+
+    act(() => {
+      result.current.handleSendMessage('hello');
+    });
+
+    await waitFor(() => expect(service.sendMessage).toHaveBeenCalled());
+
+    expect(result.current.messages[0].parts[0].text).toBe('hello');
+    expect(result.current.messages[1].parts[0].text).toBe('answer');
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ import { fileURLToPath, URL } from 'node:url';
 export default defineConfig(({ mode }) => {
   // Load env file based on `mode` in the current directory.
   const env = loadEnv(mode, process.cwd(), '');
-  
+
   // Determine the API URL based on the environment
   const apiUrl = env.VITE_API_URL || 'http://localhost:3001';
   const isProduction = mode === 'production';
@@ -17,59 +17,56 @@ export default defineConfig(({ mode }) => {
   return {
     base: '/',
     publicDir: 'public',
-    plugins: [
-      react(),
-    ],
+    plugins: [react()],
     css: {
       postcss: {
-        plugins: [
-          tailwindcss(),
-          autoprefixer(),
-        ],
+        plugins: [tailwindcss(), autoprefixer()],
       },
       devSourcemap: !isProduction,
       modules: {
         localsConvention: 'camelCaseOnly',
       },
     },
-    
+
     // Environment variables that should be exposed to the client
     define: {
       'process.env.NODE_ENV': JSON.stringify(mode),
       'process.env.VITE_API_URL': JSON.stringify(apiUrl),
     },
-    
+
     // Server configuration
     server: {
       port: 3000,
       strictPort: true,
       open: !process.env.CI,
-      proxy: !isProduction ? {
-        // Proxy API requests in development to avoid CORS issues
-        '/api': {
-          target: 'http://localhost:3001',
-          changeOrigin: true,
-          secure: false,
-          ws: true,
-          // Don't rewrite the /api prefix
-          rewrite: (path) => path,
-          // Configure CORS headers for development
-          configure: (proxy, _options) => {
-            proxy.on('error', (err, _req, _res) => {
-              console.error('Proxy error:', err);
-            });
-            proxy.on('proxyReq', (proxyReq, req, _res) => {
-              console.log('Proxying request to backend:', req.method, req.url);
-              console.log('Request headers:', JSON.stringify(req.headers, null, 2));
-            });
-            proxy.on('proxyRes', (proxyRes, req, _res) => {
-              console.log('Response from backend:', proxyRes.statusCode, req.url);
-            });
+      proxy: !isProduction
+        ? {
+            // Proxy API requests in development to avoid CORS issues
+            '/api': {
+              target: 'http://localhost:3001',
+              changeOrigin: true,
+              secure: false,
+              ws: true,
+              // Don't rewrite the /api prefix
+              rewrite: (path) => path,
+              // Configure CORS headers for development
+              configure: (proxy, _options) => {
+                proxy.on('error', (err, _req, _res) => {
+                  console.error('Proxy error:', err);
+                });
+                proxy.on('proxyReq', (proxyReq, req, _res) => {
+                  console.log('Proxying request to backend:', req.method, req.url);
+                  console.log('Request headers:', JSON.stringify(req.headers, null, 2));
+                });
+                proxy.on('proxyRes', (proxyRes, req, _res) => {
+                  console.log('Response from backend:', proxyRes.statusCode, req.url);
+                });
+              },
+            },
           }
-        },
-      } : undefined,
+        : undefined,
     },
-    
+
     // Build configuration
     build: {
       outDir: 'dist',
@@ -97,35 +94,34 @@ export default defineConfig(({ mode }) => {
         include: /node_modules/,
       },
     },
-    
+
     // Preview configuration
     preview: {
       port: 3000,
       strictPort: true,
       open: !process.env.CI,
     },
-    
+
     // Resolve configuration
     resolve: {
       alias: {
         '@': fileURLToPath(new URL('./src', import.meta.url)),
       },
     },
-    
+
     // Optimize dependencies
     optimizeDeps: {
-      include: [
-        'react',
-        'react-dom',
-        'react-router-dom',
-        '@google/generative-ai',
-        'axios',
-      ],
+      include: ['react', 'react-dom', 'react-router-dom', '@google/generative-ai', 'axios'],
       exclude: ['@google/generative-ai'],
       esbuildOptions: {
         // Enable esbuild's tree shaking
         treeShaking: true,
       },
+    },
+
+    test: {
+      globals: true,
+      environment: 'jsdom',
     },
   };
 });


### PR DESCRIPTION
## Summary
- configure vitest to use jsdom
- remove vitest plugin from ESLint config
- add basic tests for useChat and ChatInterface components
- add simple App render test

## Testing
- `npx eslint . --ext .ts,.tsx` *(fails: resolve errors in existing files)*
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c093abfcc83338c11f67ff91ea622