### PR TITLE
[Fix] default relative API URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,8 @@ GEMINI_MODEL_NAME=gemini-2.5-flash-preview-04-17
 # Environment (development, production)
 NODE_ENV=development
 
-# API URL (for development)
-VITE_API_URL=http://localhost:3000
+# API URL (optional, e.g. https://your-app.vercel.app)
+VITE_API_URL=
 
 # Vercel URL (automatically set by Vercel)
 VERCEL_URL=

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -4,12 +4,11 @@ export interface ApiResponse<T> {
 }
 
 const getApiUrl = () => {
-  if (import.meta.env.PROD) {
-    // Use the full URL in production
-    return 'https://legal-chat-i5hldtcl9-zombua-7423s-projects.vercel.app/api/chat';
+  const base = import.meta.env.VITE_API_URL;
+  if (base) {
+    return `${base.replace(/\/$/, '')}/api/chat`;
   }
-  const base = import.meta.env.VITE_API_URL || 'http://localhost:3000';
-  return `${base}/api/chat`;
+  return '/api/chat';
 };
 
 export const apiClient = {

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -2,14 +2,11 @@ import type { GroundingSource, Message } from '../types';
 
 // Get the API URL based on the environment
 const getApiUrl = (): string => {
-  // In production, use relative URL (handled by Vercel rewrites)
-  if (import.meta.env.PROD) {
-    return '/api/chat';
+  const baseUrl = import.meta.env.VITE_API_URL;
+  if (baseUrl) {
+    return `${baseUrl.replace(/\/$/, '')}/api/chat`;
   }
-
-  // In development, use the full URL from environment variable or default
-  const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
-  return `${baseUrl}/api/chat`;
+  return '/api/chat';
 };
 
 export const sendMessage = async (
@@ -37,7 +34,8 @@ export const sendMessage = async (
       message: message.trim(),
     };
 
-    if (import.meta.env.DEV) console.log('Request payload:', JSON.stringify(payload, null, 2));
+    if (import.meta.env.DEV)
+      console.log('Request payload:', JSON.stringify(payload, null, 2));
 
     const response = await fetch(apiUrl, {
       method: 'POST',
@@ -54,7 +52,8 @@ export const sendMessage = async (
     try {
       data = responseText ? JSON.parse(responseText) : {};
     } catch (e) {
-      if (import.meta.env.DEV) console.error('Failed to parse JSON response:', responseText);
+      if (import.meta.env.DEV)
+        console.error('Failed to parse JSON response:', responseText);
       throw new Error('Invalid JSON response from server');
     }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,20 +21,23 @@ export default defineConfig(({ mode }) => {
     define: {
       'process.env': {
         NODE_ENV: JSON.stringify(mode),
-        VITE_API_URL: JSON.stringify(env.VITE_API_URL || (isProduction ? 'https://legal-chat-i5hldtcl9-zombua-7423s-projects.vercel.app/api' : 'http://localhost:3000/api'))
-      }
+        VITE_API_URL: JSON.stringify(env.VITE_API_URL || ''),
+      },
     },
     server: {
       port: 3000,
       open: true,
-      proxy: !isProduction ? {
-        '/api': {
-          target: 'http://localhost:3000',
-          changeOrigin: true,
-          secure: false,
-          rewrite: (path) => path.replace(/^\/api/, '')
-        }
-      } : undefined,
+      proxy:
+        !isProduction && env.VITE_API_URL
+          ? {
+              '/api': {
+                target: env.VITE_API_URL,
+                changeOrigin: true,
+                secure: false,
+                rewrite: (path) => path.replace(/^\/api/, ''),
+              },
+            }
+          : undefined,
     },
     build: {
       outDir: 'dist',
@@ -60,7 +63,13 @@ export default defineConfig(({ mode }) => {
     },
     // Optimize dependencies
     optimizeDeps: {
-      include: ['react', 'react-dom', 'react-router-dom', '@google/generative-ai', 'axios'],
+      include: [
+        'react',
+        'react-dom',
+        'react-router-dom',
+        '@google/generative-ai',
+        'axios',
+      ],
       exclude: ['@google/generative-ai'],
       esbuildOptions: {
         // Enable esbuild's tree shaking


### PR DESCRIPTION
## Summary
- default API client to `/api/chat` when `VITE_API_URL` isn't set
- adjust Gemini service to match new API URL logic
- make dev proxy use `VITE_API_URL` if provided
- update `.env.example`

## Testing
- `npx prettier --write src/services/apiClient.ts src/services/geminiService.ts vite.config.ts`
- `npx eslint . --ext .ts,.tsx` *(fails: ESLint couldn't find plugin)*
- `npm run build`

Closes #1

------
https://chatgpt.com/codex/tasks/task_e_684c2bd6a328833392a2d4d7ed7b57d9